### PR TITLE
Adding a strands_extras metapackage

### DIFF
--- a/strands_extras/CMakeLists.txt
+++ b/strands_extras/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(strands_extras)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/strands_extras/package.xml
+++ b/strands_extras/package.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0"?>
 <package>
-  <name>strands_desktop</name>
+  <name>strands_extras</name>
   <version>0.0.8</version>
   <description>A metapackage to aggregate several packages.</description>
   <maintainer email="marc@hanheide.net">Marc Hanheide</maintainer>
@@ -7,17 +8,12 @@
 
   <url type="repository">https://github.com/strands-project/metapackages</url>
   <url type="bugtracker">https://github.com/strands-project/metapackages/issues</url>
-
+  
   <buildtool_depend>catkin</buildtool_depend>
-
-  <!-- simulation -->
-  <run_depend>strands_morse</run_depend>
-  <run_depend>morse-blender-bundle</run_depend>
-
-  <run_depend>strands_base</run_depend>
-  <run_depend>strands_extras</run_depend>
+  
+  <run_depend>strands_qsr_lib</run_depend>
 
   <export>
-    <metapackage/>
+    <metapackage/> 
   </export>
 </package>

--- a/strands_robot/package.xml
+++ b/strands_robot/package.xml
@@ -16,6 +16,7 @@
   <run_depend>sicks300</run_depend>
 
   <run_depend>strands_base</run_depend>
+  <run_depend>strands_extras</run_depend>
 
   <export>
     <metapackage/>


### PR DESCRIPTION
Currently this only contains strands_qsr_lib but since this did not feel like being part of a base system, I created this extras package which might become more populated and some of the packages from base could maybe moved here as well.

@marc-hanheide is this what you had in mind? If so, I'll open one for indigo as well.

PR will most likely fails because the strands_qsr_lib meta package has not been released yet due to jenkins issues.
